### PR TITLE
Removing token from config.edn and adding token-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and its pretty straightforward, here is an example with the defaults:
                  "mvessel" "https://rawgit.com/47deg/microsites/cdn//mvessel/navbar_brand.png"
                  "github4s" "https://rawgit.com/47deg/microsites/cdn//github4s/navbar_brand.png"
                  "scalacheck-datetime" "https://rawgit.com/47deg/microsites/cdn//scalacheck-datetime/navbar_brand.png"}
- :token "a-github-token"
+ :token-name "an-env-variable-with-a-github-api-key"
  :analytics "a-google-analytics-token"
  :footer {:acknowledgment true}
  :style {:primary-color "#F44336"
@@ -95,7 +95,7 @@ Let's break it down:
 - `:included-projects` is the set with the projects you are interested in having on the site
 - `:extra-repos` allows you to add extra repos out of the org (maps with `:user` and `:repo`)
 - `:project-logos` is a map from project names to the URL where their logo can be found, libraries without logos will show a placeholder
-- `:token` is a string containing the GitHub token required to use the GitHub API
+- `:token-name` is a string with the name of an environment variable containing a GitHub token required to use the GitHub API
 - `:style` is a map with style configuration
  + `:primary-color` sets the primary color of the webpage
  + `:header` controls the styles of the header, only `:background` is supported for now

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -41,7 +41,7 @@
                  "nine-cards-v2" "//47deg.github.io/nine-cards-v2/img/navbar_brand.png"
                  "nine-cards-backend" "//47deg.github.io/nine-cards-v2/img/navbar_brand.png"
                  "case-classy" "//47deg.github.io/case-classy/img/navbar_brand.png"}
- :token "cb47c4423aecc8bbaff9c3dfe6f059ffcc978e64"
+ :token-name "GITHUB_API_KEY"
  :analytics "UA-18433785-13"
  :style {:primary-color "#F44336"
          :header {:background "linear-gradient(0deg, rgba(30, 39, 53, 0.88), rgba(30, 39, 53, 0.88)), url(\"img/header-background.jpg\") no-repeat center center"

--- a/src/org/app.cljs
+++ b/src/org/app.cljs
@@ -17,7 +17,7 @@
 (defn init!
   []
   (let [state (atom (read-state!))
-        {:keys [organization token extra-repos analytics] :as config} (:config @state)]
+        {:keys [organization token-name extra-repos analytics] :as config} (:config @state)]
     ;; turn on analytics
     (when analytics
       (js/ga "create" analytics "auto")

--- a/src/org/build.clj
+++ b/src/org/build.clj
@@ -91,7 +91,7 @@
                :verbose true}))
 
 (defn render-page
-  [repos {:keys [organization token] :as config} js-root]
+  [repos {:keys [organization token-name] :as config} js-root]
   (let [state (atom (assoc st/default-state :repos repos :config config))
         component (page state {:js-root js-root})]
     (rum/render-html component)))
@@ -101,7 +101,7 @@
   (render-page repos config ""))
 
 (defn render-index-page
-  [repos {:keys [organization token] :as config}]
+  [repos {:keys [organization token-name] :as config}]
   (render-page repos config "js/compiled/"))
 
 (defn read-config!
@@ -109,8 +109,8 @@
   (clojure.edn/read-string (slurp (clojure.java.io/resource path))))
 
 (defn fetch-data!
-  [{:keys [organization token extra-repos]}]
-  @(c/fetch-org-and-extra-repos! organization {:token token
+  [{:keys [organization token-name extra-repos]}]
+  @(c/fetch-org-and-extra-repos! organization {:token-name token-name
                                                :extra-repos extra-repos}))
 
 (defn make-dirs!
@@ -120,7 +120,7 @@
 
 (defn generate-index!
   [file repos config]
-  (spit file (render-static-page repos config)))
+   (spit file (render-static-page repos config)))
 
 (defn compile-css!
   [file style-config]

--- a/src/org/config.cljc
+++ b/src/org/config.cljc
@@ -47,7 +47,7 @@
 
 ;; Tokens
 
-(s/def :org/token string?)
+(s/def :org/token-name string?)
 (s/def :org/analytics string?)
 
 ;; Style
@@ -96,7 +96,7 @@
                                     :org/links
                                     :org/languages
                                     :org/included-projects
-                                    :org/token
+                                    :org/token-name
                                     :org/style]
                            :opt-un [:org/organization-name
                                     :org/social


### PR DESCRIPTION
This PR is related with #60 and removes the token with a github api key from config.edn and adds a new token-name with the name of an environment variable containing a github api key. 

@anamariamv could you please review?

Thanks!