### PR TITLE
Don't use ancient Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: clojure
 
 before_install:
- - rvm install 2.0.0
  - gem install sass
  
 branches:


### PR DESCRIPTION
A dependency from `Sass` is [causing the Travis build to fail](https://travis-ci.org/47deg/org/builds/496625213?utm_source=github_status&utm_medium=notification) because is not compatible with Ruby 2.0.0. I've opened #79 to move away from the Ruby gem, but I'm opening this PR to trigger a successful build of the website in Travis.